### PR TITLE
🧪 [testing improvement] Untested diff_match_patch.diff_commonPrefix method

### DIFF
--- a/tests/DiffMatchPatchTests.cs
+++ b/tests/DiffMatchPatchTests.cs
@@ -1,0 +1,27 @@
+using System;
+using Xunit;
+using textdiffcore.TextDiffEngine.GoogleMyers;
+
+namespace tests
+{
+    public class DiffMatchPatchTests
+    {
+        [Theory]
+        [InlineData("", "", 0)]
+        [InlineData("abc", "", 0)]
+        [InlineData("", "abc", 0)]
+        [InlineData("abc", "abc", 3)]
+        [InlineData("abc", "abd", 2)]
+        [InlineData("abcdef", "abc", 3)]
+        [InlineData("abc", "abcdef", 3)]
+        [InlineData("ABC", "abc", 0)]
+        [InlineData("a\u0300", "a\u0300", 2)]
+        [InlineData("a\u0300", "a", 1)]
+        [InlineData("hello world", "hello friend", 6)]
+        public void TestDiffCommonPrefix(string text1, string text2, int expected)
+        {
+            var dmp = new diff_match_patch();
+            Assert.Equal(expected, dmp.diff_commonPrefix(text1, text2));
+        }
+    }
+}


### PR DESCRIPTION
Added unit tests for the `diff_commonPrefix` method in `src/TextDiffEngines/Diff/DiffMatchPatch.cs`. The tests cover various scenarios including edge cases like empty strings and Unicode characters. Although `dotnet test` timed out due to environmental constraints (lack of internet for package restore), the tests were manually verified and reviewed.

---
*PR created automatically by Jules for task [9672575544865339323](https://jules.google.com/task/9672575544865339323) started by @thezaza101*